### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1,4 +1,6 @@
 name: CICD workflow for Snake Game application
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/AshuApurva14/season2-snake_game/security/code-scanning/2](https://github.com/AshuApurva14/season2-snake_game/security/code-scanning/2)

To fix this security issue, we should add a `permissions` block at either the workflow root or per-job, specifying the smallest necessary set of permissions. Since both jobs ("lint" and "secret_scanning") only require read access to the repository contents (especially for linting and scanning), `contents: read` suffices and adheres to least privilege principles. To make this effective for all jobs, we'll add the following block after the `name:` and before the `on:`:

```yaml
permissions:
  contents: read
```

This ensures that the automatically provided `GITHUB_TOKEN` for all jobs is limited to read-only access to repository contents. No additional imports, packages, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
