### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1,4 +1,6 @@
 name: CICD workflow for Snake Game application
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/AshuApurva14/season2-snake_game/security/code-scanning/1](https://github.com/AshuApurva14/season2-snake_game/security/code-scanning/1)

To fix the problem, an explicit `permissions` block should be added to the workflow to restrict the `GITHUB_TOKEN` to read-only access, unless greater permissions are required for specific jobs or steps. The least-privilege starting point is:

```yaml
permissions:
  contents: read
```

This can be added at the workflow level (right below the `name` key and above the `on` block, affecting all jobs). If any job or step requires different permissions, a more granular `permissions` block can be defined for that job. In this case, there is no evidence that any job requires more than read access, so a top-level `permissions: contents: read` is appropriate.

The only required change is to add this block at the top of the file, immediately after the `name:` line and before `on:` (after line 1 and before line 3).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
